### PR TITLE
Include blocks submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "blocks"]
+	path = blocks
+	url = https://github.com/tangrams/blocks

--- a/layers/buildings.yaml
+++ b/layers/buildings.yaml
@@ -126,8 +126,8 @@ styles:
         mix: [geometry-dynamic-width, geometry-dynamic-height]
         shaders:
             defines:
-                ZOOM_START: 16
-                ZOOM_END: 20
+                ZOOM_START: 16.
+                ZOOM_END: 20.
                 WIDTH_MIN: .7
                 WIDTH_MAX: 1.0
 

--- a/layers/roads.yaml
+++ b/layers/roads.yaml
@@ -508,7 +508,7 @@ styles:
         mix: [functions-zoom, lines-glow]
         shaders:
             defines:
-                ZOOM_START: 5
+                ZOOM_START: 5.
                 ZOOM_END: 6.
                 GLOW_WIDTH: mix(1.,.45,zoom())
                 GLOW_BRIGHTNESS: zoom()*.25

--- a/styles/common.yaml
+++ b/styles/common.yaml
@@ -1,8 +1,8 @@
 import:
-    - https://tangrams.github.io/blocks/functions/zoom.yaml
-    - https://tangrams.github.io/blocks/geometry/dynamic-width.yaml
-    - https://tangrams.github.io/blocks/geometry/dynamic-height.yaml
-    - https://tangrams.github.io/blocks/filter/tv.yaml
+    - ../blocks/functions/zoom.yaml
+    - ../blocks/geometry/dynamic-width.yaml
+    - ../blocks/geometry/dynamic-height.yaml
+    - ../blocks/filter/tv.yaml
 
 styles:
     tron-palette:

--- a/styles/lines.yaml
+++ b/styles/lines.yaml
@@ -1,6 +1,6 @@
 import:
     # Blocks
-    - https://tangrams.github.io/blocks/lines/glow.yaml
+    - ../blocks/lines/glow.yaml
 
 styles:
     lines-coast:

--- a/styles/polygons.yaml
+++ b/styles/polygons.yaml
@@ -1,14 +1,14 @@
 import:
     # Blocks
-    - https://tangrams.github.io/blocks/elevation/stripes.yaml
-    - https://tangrams.github.io/blocks/elevation/contours.yaml
-    - https://tangrams.github.io/blocks/polygons/dots.yaml
-    - https://tangrams.github.io/blocks/polygons/shimmering.yaml
-    - https://tangrams.github.io/blocks/polygons/stripes.yaml
-    - https://tangrams.github.io/blocks/polygons/diagonal-stripes.yaml
-    - https://tangrams.github.io/blocks/polygons/diagonal-grid.yaml
+    - ../blocks/elevation/stripes.yaml
+    - ../blocks/elevation/contours.yaml
+    - ../blocks/polygons/dots.yaml
+    - ../blocks/polygons/shimmering.yaml
+    - ../blocks/polygons/stripes.yaml
+    - ../blocks/polygons/diagonal-stripes.yaml
+    - ../blocks/polygons/diagonal-grid.yaml
     # Utils
-    - https://tangrams.github.io/blocks/geometry/normal.yaml
+    - ../blocks/geometry/normal.yaml
     # Custom Commons
     - ./common.yaml
 


### PR DESCRIPTION
This should ease tweaking Blocks during development. It's probably not compatible with loading the ghpages url into tangram-play though.

I'm currently trying to figure out how to match `water-later` style on ES where the pattern is not fixed to world-space but moves independently. 
