### PR TITLE
Fix shader patterns that relied on canvas compositing

### DIFF
--- a/layers/earth.yaml
+++ b/layers/earth.yaml
@@ -41,6 +41,9 @@ styles:
                 STRIPES_ALPHA: 1.
                 STRIPES_SCALE: mix(25.,50.,smoothstep(0.,1.,1.-zoom()))
                 STRIPES_WIDTH: 1.-zoom()-.2
+            blocks:
+                # Use alpha from pattern to scale rgb values
+                color: color = vec4(color.rgb * color.a, 1.);
 
     urban-early:
         base: polygons

--- a/layers/water.yaml
+++ b/layers/water.yaml
@@ -161,6 +161,9 @@ styles:
                 STRIPES_ALPHA: 1.
                 STRIPES_SCALE: 25.
                 STRIPES_WIDTH: zoom()
+            blocks:
+                # Use alpha from pattern to scale rgb values
+                color: color = vec4(color.rgb * color.a, 1.);
 
     water-later:
         base: polygons


### PR DESCRIPTION
In WebGL, alpha values from any fragments (even those with blending off) are used to composite the color buffer with the canvas background. This does not happen in OpenGL ES. The 'stripes' pattern works in WebGL by changing the alpha value of a fragment and allowing the canvas to
blend the background color into the final result. In OpenGL ES, no such blending happens. This change applies the fragment alpha to the color values before canvas composition and then returns the alpha value to 1, resulting in consistent behavior in WebGL and OpenGL ES.

This resolves the last problem described in https://github.com/tangrams/tron/issues/83
