### PR TITLE
Styles w/animation should be explicitly marked as animated

### DIFF
--- a/layers/roads.yaml
+++ b/layers/roads.yaml
@@ -667,6 +667,7 @@ styles:
     runway-dots:
         base: lines
         mix: [lines-dots-glow]
+        animated: true
         shaders:
             defines:
                 DOTS_ANIMATE: color.a *=abs(sin(v_texcoord.y+u_time))*1.0

--- a/styles/lines.yaml
+++ b/styles/lines.yaml
@@ -7,6 +7,7 @@ import:
 styles:
     lines-coast:
         base: lines
+        animated: true
         texcoords: true
         blend: add
         shaders:
@@ -29,6 +30,7 @@ styles:
                     color *= pct;
     lines-traffic-animation:
         base: lines
+        animated: true
         mix: [generative-random, tron-palette, functions-zoom]
         texcoords: true
         shaders:
@@ -36,7 +38,7 @@ styles:
                 ZOOM_START: 11.
                 ZOOM_END: 18.
                 DATASTREAM_SPEED: 50.
-                DATASTREAM_ROADS: 5.0 
+                DATASTREAM_ROADS: 5.0
                 DATASTREAM_MARGIN: z*.3
                 DATASTREAM_COLOR: palette( fract(floor(v_texcoord.x*DATASTREAM_ROADS)/DATASTREAM_ROADS+u_time*.1)*z )
                 DATASTREAM_AMOUNT: .8
@@ -58,11 +60,11 @@ styles:
                       datastream_speed *= -1.;
                     }
                     #endif
-                    
+
                     color.rgb = mix(color.rgb,
                                     DATASTREAM_COLOR,
                                     z*
-                                    datastream_pattern( st, 
+                                    datastream_pattern( st,
                                                         (u_time*DATASTREAM_SPEED)*datastream_speed,
                                                         DATASTREAM_AMOUNT)*
                                                     smoothstep(DATASTREAM_MARGIN,1.,sin(fract(v_texcoord.x*DATASTREAM_ROADS)*3.1415))

--- a/styles/polygons.yaml
+++ b/styles/polygons.yaml
@@ -22,7 +22,7 @@ styles:
                 filter: |
                     color.rgb = mix(BACKGROUND_COLOR,color.rgb, color.a);
                     color.a = 1.;
-                    
+
     polygons-building-wall:
         base: polygons
         mix: [functions-zoom, geometry-normal,generative-random, tron-palette, geometry-dynamic-height]
@@ -65,20 +65,21 @@ styles:
     polygons-shimmering:
         base: polygons
         mix: [functions-zoom, tiling-simplex, generative-noise]
+        animated: true
         shaders:
             defines:
                 ZOOM_START: 11.
                 ZOOM_END: 20.
                 SHIMMERING_ZOOM_IN: 0.01
                 SHIMMERING_ZOOM_OUT: 30.
-                
+
                 SHIMMERING_SCALE: 1.
                 SHIMMERING_COLOR: color.rgb
                 SHIMMERING_BACKGROUND_COLOR: color.rgb*.5
                 SHIMMERING_SPEED: 0.1
                 SHIMMERING_AMOUNT: 1.
                 SHIMMERING_ANIMATED: true
-                
+
                 SPACE_CONSTANT_PIXEL_SCALE: 695.
                 SPACE_CONSTANT_DOT_WRAP: 1e4
             blocks:


### PR DESCRIPTION
After the discussion of optimizing scene animation behavior in https://github.com/tangrams/tangram-es/pull/1901 (and corresponding change for JS in https://github.com/tangrams/tangram/commit/7c5c79970fe0279e0dfae04c95168c1be0aaaac4), I discovered an issue with Tron's style definitions.

While Tron uses a global `sdk_animated` to control both the `scene.animated` flag and the behavior of various style shaders, it **does not** explicitly mark animated styles as `animated: true`. This means the renderer doesn't have the necessary knowledge to toggle animation based on the styles currently in view.

As a result, with the changes linked to above, the style will no longer animate at all, because once `scene.animated` is set to `false`, it never finds any styles with `animated: true`.

This PR fixes this by appropriate marking the styles as animated.

